### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,42 +2,40 @@ FROM ubuntu:18.04 as sim_builder
 RUN apt-get update && \
     apt-get -y install build-essential xterm man wget readline-common libreadline-dev sudo unzip \
                        cmake autoconf automake libtool m4 gfortran libtool-bin xorg xorg-dev bc \
-                       libopenmpi-dev gfortran-multilib
+                       libopenmpi-dev gfortran-multilib curl
 WORKDIR /tmp
-RUN wget -nv https://www.classe.cornell.edu/~cesrulib/downloads/tarballs/bmad_dist_2019_0129.tgz
-WORKDIR /
-RUN tar -xvf /tmp/bmad_dist_2019_0129.tgz -C /
-COPY bmad_env.bash /bmad_dist_2019_0129/bmad_env.bash
 SHELL ["/bin/bash", "-c"]
+RUN curl https://www.classe.cornell.edu/~cesrulib/downloads/tarballs/ | sed -n 's/.*href="\([^"]*\)\.tgz.*/\1/p' > /bmad_filename.txt
+RUN wget -nv "https://www.classe.cornell.edu/~cesrulib/downloads/tarballs/$(cat /bmad_filename.txt).tgz"
+WORKDIR /
+RUN tar -xvf /tmp/$(cat /bmad_filename.txt).tgz -C /
+RUN mv $(cat /bmad_filename.txt) bmad
+COPY bmad_env.bash /bmad/bmad_env.bash
 RUN ln -s /usr/bin/make /usr/bin/gmake
-RUN cd /bmad_dist_2019_0129 && \
+RUN cd /bmad && \
     pwd && \
     ls -la && \
     source ./bmad_env.bash && \
-    sed -i 's/ACC_ENABLE_OPENMP.*/ACC_ENABLE_OPENMP="Y"/' /bmad_dist_2019_0129/util/dist_prefs && \
-    sed -i 's/ACC_ENABLE_MPI.*/ACC_ENABLE_MPI="Y"/' /bmad_dist_2019_0129/util/dist_prefs && \
-    sed -i 's/ACC_ENABLE_SHARED.*/ACC_ENABLE_SHARED="Y"/' /bmad_dist_2019_0129/util/dist_prefs && \
-    sed -i 's/ACC_ENABLE_MPI.*/ACC_ENABLE_MPI="Y"/' /bmad_dist_2019_0129/util/dist_prefs && \
-    sed -i 's:CMAKE_Fortran_COMPILER\} MATCHES "ifort":CMAKE_Fortran_COMPILER\} STREQUAL "ifort":' /bmad_dist_2019_0129/build_system/Master.cmake && \
-    sed -i '/export PACKAGE_VERSION=/a source .\/VERSION' /bmad_dist_2019_0129/openmpi/acc_build_openmpi
-WORKDIR /bmad_dist_2019_0129
+    sed -i 's/ACC_ENABLE_OPENMP.*/ACC_ENABLE_OPENMP="Y"/' /bmad/util/dist_prefs && \
+    sed -i 's/ACC_ENABLE_MPI.*/ACC_ENABLE_MPI="Y"/' /bmad/util/dist_prefs && \
+    sed -i 's/ACC_ENABLE_SHARED.*/ACC_ENABLE_SHARED="Y"/' /bmad/util/dist_prefs && \
+    sed -i 's/ACC_ENABLE_MPI.*/ACC_ENABLE_MPI="Y"/' /bmad/util/dist_prefs && \
+    sed -i 's:CMAKE_Fortran_COMPILER\} MATCHES "ifort":CMAKE_Fortran_COMPILER\} STREQUAL "ifort":' /bmad/build_system/Master.cmake && \
+    sed -i '/export PACKAGE_VERSION=/a source .\/VERSION' /bmad/openmpi/acc_build_openmpi
+
+WORKDIR /bmad
 RUN source ./bmad_env.bash && ./util/dist_build_production
 
-
 FROM ubuntu:18.04
-COPY --from=sim_builder /bmad_dist_2019_0129/bmad /bmad_dist_2019_0129/bmad
-COPY --from=sim_builder /bmad_dist_2019_0129/build_system /bmad_dist_2019_0129/build_system
-COPY --from=sim_builder /bmad_dist_2019_0129/util /bmad_dist_2019_0129/util
-COPY --from=sim_builder /bmad_dist_2019_0129/tao /bmad_dist_2019_0129/tao
-COPY --from=sim_builder /bmad_dist_2019_0129/production /bmad_dist_2019_0129/production
-COPY bmad_env.bash /bmad_dist_2019_0129/bmad_env.bash
+COPY --from=sim_builder /bmad/production/lib/libtao.so /tao/libtao.so
+COPY --from=sim_builder /bmad/tao/python/pytao /tao/pytao
 RUN apt-get update && apt-get -y install readline-common python3 python3-pip libzmq5 libx11-6 gfortran
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN pip3 install numpy caproto pyzmq
 SHELL ["/bin/bash", "-c"]
 COPY . /simulacrum
 RUN cd /simulacrum && pip3 install . 
-COPY bpm_sim /bpm_sim
+COPY bpm_service /bpm_service
 COPY model_service /model_service
 ENV MODEL_PORT 12312
 ENV ORBIT_PORT 56789
@@ -46,4 +44,4 @@ ENV EPICS_CA_REPEATER_PORT 5065
 EXPOSE ${MODEL_PORT}
 EXPOSE ${ORBIT_PORT}
 EXPOSE ${EPICS_CA_SERVER_PORT}
-ENTRYPOINT cd /bmad_dist_2019_0129 && source ./bmad_env.bash && cd /model_service && (python3 model_service.py &) && cd /bpm_sim && python3 bpm_service.py
+#ENTRYPOINT cd /model_service && (python3 model_service.py &)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 > simulacrum (Noun):
 >	1. An image or representation of someone or something.
 >	*'a small-scale simulacrum of a skyscraper'*
+>
 >	1.1 An unsatisfactory imitation or substitute.
 >	*'a bland simulacrum of American soul music'*
+>
 > --Oxford English Dictionary
 
 Simulacrum is a system to simulate the LCLS accelerator and its control system.  It is comprised of a set of "services", individual processes that each simulate a different subsystem.  These processes can communicate with each other via ZeroMQ, can communicate with the user (and their software) via EPICS Channel Access.  The goal of this project is to run unmodified accelerator software (and develop new software), but with data coming from the simulator, rather than the real machine.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Simulacrum: The LCLS Accelerator Simulator
+
+> simulacrum (Noun):
+>	1. An image or representation of someone or something.
+>	*'a small-scale simulacrum of a skyscraper'*
+>	1.1 An unsatisfactory imitation or substitute.
+>	*'a bland simulacrum of American soul music'*
+> --Oxford English Dictionary
+
+Simulacrum is a system to simulate the LCLS accelerator and its control system.  It is comprised of a set of "services", individual processes that each simulate a different subsystem.  These processes can communicate with each other via ZeroMQ, can communicate with the user (and their software) via EPICS Channel Access.  The goal of this project is to run unmodified accelerator software (and develop new software), but with data coming from the simulator, rather than the real machine.
+
+The project provides a Dockerfile, which can be used to build a fully isolated container containing everything you need to get going.  You can either pull a pre-build image from Docker Hub (`docker pull itsmattgibbs/simulacrum`), or clone the Simulacrum repository and build the container yourself (this takes several hours).

--- a/bmad_env.bash
+++ b/bmad_env.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-export DIST_BASE_DIR=/bmad_dist_2019_0129
+export DIST_BASE_DIR=/bmad
 source ${DIST_BASE_DIR}/util/dist_source_me
 ulimit -S -c 0
 ulimit -S -d 25165824

--- a/model_service/model_service.py
+++ b/model_service/model_service.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import pickle
-TAO_PYTHON_DIR=os.environ['ACC_ROOT_DIR'] + '/tao/python'
+TAO_PYTHON_DIR='/tao'
 sys.path.insert(0, TAO_PYTHON_DIR)
 import pytao
 import numpy as np
@@ -11,7 +11,7 @@ from zmq.asyncio import Context
 
 class ModelService:
     def __init__(self):
-        self.tao = pytao.Tao()
+        self.tao = pytao.Tao(so_lib='/tao/libtao.so')
         self.tao.init("-noplot -lat lcls.lat")
         self.ctx = Context.instance()
         #self.orbit_socket = self.ctx.socket(zmq.PUB)


### PR DESCRIPTION
The Dockerfile is improved in several ways:
* The latest BMAD tarball is now downloaded, rather than a hard-coded one.
* The build process only copies the bare minimum Tao products needed to run the model service.  The final image size is now 681 MB (down from 3.65 GB!)
* The container's 'ENTRYPOINT' has been removed - it is now up to the end user to decide what they want to start up inside the container.