### PR TITLE
Generic PV Service

### DIFF
--- a/generic_pv_service/generic_pv_service.py
+++ b/generic_pv_service/generic_pv_service.py
@@ -1,0 +1,103 @@
+from caproto import (ChannelString, ChannelEnum, ChannelDouble,
+                     ChannelChar, ChannelData, ChannelInteger,
+                     ChannelByte, ChannelShort, AccessRights,
+                     ChannelType)
+from caproto.server import ioc_arg_parser, run
+import simulacrum
+
+class ChannelBool(ChannelEnum):
+    def __init__(self, *, enum_strings=None, **kwargs):
+        if enum_strings is None:
+            enum_strings = ['Off', 'On']
+            super().__init__(enum_strings=enum_strings, **kwargs)
+           
+class_for_type = {
+    'str': str,
+    'bytes': bytes,
+    'int': int,
+    'float': float,
+    'bool': bool,
+    
+    str: str,
+    bytes: bytes,
+    int: int,
+    float: float,
+    bool: bool
+}           
+           
+channel_type_map = {
+    'str': ChannelString,
+    'bytes': ChannelByte,
+    'int': ChannelInteger,
+    'float': ChannelDouble,
+    'bool': ChannelBool,
+    
+    str: ChannelString,
+    bytes: ChannelByte,
+    int: ChannelInteger,
+    float: ChannelDouble,
+    bool: ChannelBool,
+
+    ChannelType.STRING: ChannelString,
+    ChannelType.INT: ChannelInteger,
+    ChannelType.LONG: ChannelInteger,
+    ChannelType.DOUBLE: ChannelDouble,
+    ChannelType.ENUM: ChannelEnum,
+    ChannelType.CHAR: ChannelChar
+}
+
+default_values = {
+    'str': '',
+    'bytes': b'',
+    'int': 0,
+    'float': 0.0,
+    'bool': False,
+    
+    str: '',
+    bytes: b'',
+    int: 0,
+    float: 0.0,
+    bool: False,
+
+    ChannelType.STRING: '',
+    ChannelType.INT: 0,
+    ChannelType.LONG: 0,
+    ChannelType.DOUBLE: 0.0,
+    ChannelType.ENUM: 0,
+    ChannelType.CHAR: '',
+}
+
+def make_channel(pvname, data_type, initial_value=None):
+    if initial_value is None:
+        initial_value = default_values[data_type]
+    if data_type in channel_type_map:
+        channel_class = channel_type_map[data_type]
+        return channel_class(value=initial_value)
+    else:
+        raise ValueError("Router doesn't know what EPICS type to use for Python type {}".format(data_type))
+
+class GenericPVService(simulacrum.Service):
+    def __init__(self):
+        super().__init__()
+        with open("pvs.txt") as f:
+            for line in f:
+                if line.startswith("#"):
+                    continue
+                pv_args = line.split(None, 2)
+                pv = pv_args[0]
+                type_for_pv = pv_args[1]
+                initial_value = None
+                if len(pv_args) > 2:
+                    initial_value = pv_args[2]
+                chan = make_channel(pv, type_for_pv, initial_value=class_for_type[type_for_pv](initial_value))
+                self[pv] = chan
+        
+def main():
+    service = GenericPVService()
+    _, run_options = ioc_arg_parser(
+        default_prefix='',
+        desc="Generic PV Service")
+    run(service, **run_options)
+    
+if __name__ == '__main__':
+    main()

--- a/generic_pv_service/generic_pv_service.py
+++ b/generic_pv_service/generic_pv_service.py
@@ -74,7 +74,7 @@ def make_channel(pvname, data_type, initial_value=None):
         channel_class = channel_type_map[data_type]
         return channel_class(value=initial_value)
     else:
-        raise ValueError("Router doesn't know what EPICS type to use for Python type {}".format(data_type))
+        raise ValueError("Generic PV service doesn't know what EPICS type to use for Python type {}".format(data_type))
 
 class GenericPVService(simulacrum.Service):
     def __init__(self):

--- a/generic_pv_service/pvs.txt
+++ b/generic_pv_service/pvs.txt
@@ -1,0 +1,10 @@
+# Define your PVs in here.
+# Lines that begin with "#" are comments, and ignored by the service.
+# The format is as follows:
+# PV_NAME TYPE INITIAL_VAL
+# Where PV_NAME is what you want the PV to be called
+# TYPE is a string corresponding to a python type: (str, float, int, bool, or bytes)
+# INITIAL_VAL is the value you want the PV to have at the start.
+# Here's a full example:
+# GDET:FEE1:241:ENRC float 3.3
+# Will create a PV called GDET:FEE1:241:ENRC, that holds a floating point number, initially 3.3


### PR DESCRIPTION
This PR adds a new service that simply hosts PVs that you define in a text file.  Almost no frills at all - you just define a PV name, a type, and an initial value.