### PR TITLE
Generic PV Service Improvements

### DIFF
--- a/generic_pv_service/generic_pv_service.py
+++ b/generic_pv_service/generic_pv_service.py
@@ -1,3 +1,4 @@
+import os
 from caproto import (ChannelString, ChannelEnum, ChannelDouble,
                      ChannelChar, ChannelData, ChannelInteger,
                      ChannelByte, ChannelShort, AccessRights,
@@ -79,7 +80,8 @@ def make_channel(pvname, data_type, initial_value=None):
 class GenericPVService(simulacrum.Service):
     def __init__(self):
         super().__init__()
-        with open("pvs.txt") as f:
+        path_to_pv_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "pvs.txt")
+        with open(path_to_pv_file) as f:
             for line in f:
                 if line.startswith("#"):
                     continue

--- a/generic_pv_service/generic_pv_service.py
+++ b/generic_pv_service/generic_pv_service.py
@@ -86,6 +86,8 @@ class GenericPVService(simulacrum.Service):
                 if line.startswith("#"):
                     continue
                 pv_args = line.split(None, 2)
+                if len(pv_args) == 0:
+                    continue
                 pv = pv_args[0]
                 type_for_pv = pv_args[1]
                 initial_value = None


### PR DESCRIPTION
* Skip blank lines in the pvs.txt file
* Open pvs.txt relative to generic_pv_service.py, so you don't have to be in the generic_pv_service/ directory for the file to open properly.