### PR TITLE
Klystron Interlocks

### DIFF
--- a/klystron_service/klystron_service.py
+++ b/klystron_service/klystron_service.py
@@ -11,10 +11,13 @@ class KlystronPV(PVGroup):
     pdes = pvproperty(value=0.0, name=':PDES')  
     phas = pvproperty(value=0.0, name=':PHAS')
     enld = pvproperty(value=0.0, name=':ENLD')
+    # The seemingly random numbers in SWRD, HDSC, DSTA, and STAT
+    # are the values these PVs have when a klystron is working normally,
+    # with no faults.
     swrd = pvproperty(value=0, name=':SWRD')
-    hdsc = pvproperty(value=0, name=':HDSC')
-    dsta = pvproperty(value=0, name=':DSTA')
-    stat = pvproperty(value=0, name=':STAT')  #TODO figure out STAT, DSTA for all green as defaults
+    hdsc = pvproperty(value=32, name=':HDSC')
+    dsta = pvproperty(value=[1610612737, 528640], name=':DSTA')
+    stat = pvproperty(value=1, name=':STAT')
     bc1s =  pvproperty(value=0, name=':BEAMCODE1_STAT')
     trim = pvproperty(value=0, name=':TRIMPHAS', dtype=ChannelType.ENUM,
                       enum_strings=("Done", "TRIM"))

--- a/model_service/lcls.lat
+++ b/model_service/lcls.lat
@@ -3944,6 +3944,30 @@ O_BC2: overlay = {O_BX21[THETA]:angle_deg*pi/180, O_BX22[THETA]:-angle_deg*pi/18
    D21OA[L]:7.8014689144809+Lp_drift*(1/cos(angle_deg*pi/180)-1/cos(bc2_theta_default)),
    D21OB[L]:7.8014689144809+Lp_drift*(1/cos(angle_deg*pi/180)-1/cos(bc2_theta_default))},
    var = {ANGLE_DEG, LP_DRIFT}, ANGLE_DEG = -1.9897364650652, LP_DRIFT = 9.8602
+
+O_K20_7: overlay = {L0A___1[GRADIENT]:f*ENLD_MeV*1e6/3.095224,
+   L0A___2[GRADIENT]:f*ENLD_MeV*1e6/3.095224,
+   L0A___3[GRADIENT]:f*ENLD_MeV*1e6/3.095224,
+   L0A___4[GRADIENT]:f*ENLD_MeV*1e6/3.095224,
+   L0A___5[GRADIENT]:f*ENLD_MeV*1e6/3.095224,
+   L0A___6[GRADIENT]:f*ENLD_MeV*1e6/3.095224,
+   L0A___7[GRADIENT]:f*ENLD_MeV*1e6/3.095224, L0A___1[PHI0]:phase_deg/360,
+   L0A___2[PHI0]:phase_deg/360, L0A___3[PHI0]:phase_deg/360, L0A___4[PHI0]:phase_deg/360,
+   L0A___5[PHI0]:phase_deg/360, L0A___6[PHI0]:phase_deg/360, L0A___7[PHI0]:phase_deg/360},
+   var = {ENLD_MEV, PHASE_DEG, F}, ENLD_MEV = 60.0,
+   F = 1
+
+O_K20_8: overlay = {L0B___1[GRADIENT]:f*ENLD_MeV*1e6/3.095224,
+   L0B___2[GRADIENT]:f*ENLD_MeV*1e6/3.095224,
+   L0B___3[GRADIENT]:f*ENLD_MeV*1e6/3.095224,
+   L0B___4[GRADIENT]:f*ENLD_MeV*1e6/3.095224,
+   L0B___5[GRADIENT]:f*ENLD_MeV*1e6/3.095224,
+   L0B___6[GRADIENT]:f*ENLD_MeV*1e6/3.095224, L0B___1[PHI0]:phase_deg/360,
+   L0B___2[PHI0]:phase_deg/360, L0B___3[PHI0]:phase_deg/360, L0B___4[PHI0]:phase_deg/360,
+   L0B___5[PHI0]:phase_deg/360, L0B___6[PHI0]:phase_deg/360},
+   var = {ENLD_MEV, PHASE_DEG, F}, ENLD_MEV = 71.0, PHASE_DEG = -2.5
+   F = 1
+
 O_K21_1: overlay = {K21_1B1[GRADIENT]:f*ENLD_MeV*1e6*0.4142135623730951/2.8692,
    K21_1B2[GRADIENT]:f*ENLD_MeV*1e6*0.4142135623730951/2.8692,
    K21_1C1[GRADIENT]:f*ENLD_MeV*1e6*0.2928932188134525/2.8692,


### PR DESCRIPTION
This PR adds logic to the Klystron Service to simulate modulator interlocks.  To cause a modulator interlock trip, you can put a new value into one of the status words (:SWRD, :HDSC, :DSTA, or :STAT).  Once it is tripped, you can use :MOD:RESET to clear the status bits, and reset the interlock.  After it is reset, you'll be able to turn the modulator back on again with :MOD:HVON_SET.

The interlocks in the real machine are extremely complex: different systems do different parts, and some trips cause secondary trips.  I'm not simulating all of that, so you'll need to take the details of the status bits with a very large grain of salt.

BONUS FEATURE: This PR also adds Tao overlays for L0A and L0B, so those PVs now work (but keep in mind, this is just modulator PVs - I haven't implemented any of the LLRF feedback PVs that we usually use to control phase/amplitude.)