### PR TITLE
Model Service Updates

### DIFF
--- a/klystron_service/klystron_service.py
+++ b/klystron_service/klystron_service.py
@@ -311,8 +311,6 @@ class KlystronService(simulacrum.Service):
         self.cmd_socket.send_pyobj({"cmd": "tao", "val": cmd})
         msg = self.cmd_socket.recv_pyobj()['result']
         L.info(msg)
-        self.cmd_socket.send_pyobj({"cmd": "send_orbit"})
-        self.cmd_socket.recv_pyobj()
    
 def main():
     service = KlystronService()

--- a/magnet_service/magnet_service.py
+++ b/magnet_service/magnet_service.py
@@ -225,17 +225,9 @@ class MagnetService(simulacrum.Service):
         self.cmd_socket.send_pyobj({"cmd": "tao", "val": "set ele {element} {attr} = {val}".format(element=magnet_pv.element_name, 
                                                                                                    attr=mag_attr,
                                                                                                    val=conv(value, l))})
-        
         self.cmd_socket.recv_pyobj()
-        L.info('Updated {}.'.format( magnet_pv.device_name ) )
-        self.cmd_socket.send_pyobj({"cmd": "send_orbit"})
-        self.cmd_socket.recv_pyobj()
-        self.cmd_socket.send_pyobj({"cmd": "send_profiles_twiss"})
-        self.cmd_socket.recv_pyobj()
-        self.cmd_socket.send_pyobj({"cmd": "send_und_twiss"})
-        self.cmd_socket.recv_pyobj()
+        L.info('Updated {}.'.format(magnet_pv.device_name))
        
-
 def main():
     service = MagnetService()
     loop = asyncio.get_event_loop()

--- a/model_service/model_service.py
+++ b/model_service/model_service.py
@@ -6,8 +6,12 @@ import pytao
 import numpy as np
 import asyncio
 import zmq
+from p4p.nt import NTTable
+from p4p.server import Server as PVAServer
+from p4p.server.asyncio import SharedPV
 from zmq.asyncio import Context
-import simulacrum 
+import simulacrum
+
 
 #set up python logger
 L = simulacrum.util.SimulacrumLog(os.path.splitext(os.path.basename(__file__))[0], level='INFO')
@@ -22,15 +26,71 @@ class ModelService:
         self.ctx = Context.instance()
         self.model_broadcast_socket = zmq.Context().socket(zmq.PUB)
         self.model_broadcast_socket.bind("tcp://*:{}".format(os.environ.get('MODEL_BROADCAST_PORT', 66666)))
-
+        self.loop = asyncio.get_event_loop()
+        self.pv = SharedPV(nt=NTTable([("element", "s"), ("s", "d"), ("l", "d"),
+                                       ("alpha_x", "d"), ("beta_x", "d"), ("eta_x", "d"), ("etap_x", "d"),
+                                       ("alpha_y", "d"), ("beta_y", "d"), ("eta_y", "d"), ("etap_y", "d")]), 
+                           initial=self.get_twiss_table(),
+                           loop=self.loop)
+        self.pva_needs_refresh = False
+        self.need_zmq_broadcast = False
+    
     def start(self):
         L.info("Starting Model Service.")
-        loop = asyncio.get_event_loop()
-        task = loop.create_task(self.recv())
+        pva_server = PVAServer(providers=[{"BMAD:SYS0:1:TWISS": self.pv}])
+        zmq_task = self.loop.create_task(self.recv())
+        pva_refresh_task = self.loop.create_task(self.refresh_pva_table())
+        broadcast_task = self.loop.create_task(self.broadcast_model_changes())
         try:
-            loop.run_until_complete(task)
+            self.loop.run_until_complete(zmq_task)
         except KeyboardInterrupt:
-            task.cancel()
+            zmq_task.cancel()
+            pva_refresh_task.cancel()
+            broadcast_task.cancel()
+            pva_server.stop()
+    
+    def get_twiss_table(self):
+        full_lattice_text = self.tao_cmd("show lat -at alpha_a -at beta_a -at eta_a -at etap_a -at alpha_b -at beta_b -at eta_b -at etap_b BEGINNING:END")
+        table_rows = []
+        for row in full_lattice_text[3:-4]:
+            _, name, _, s, l, alpha_x, beta_x, eta_x, etap_x, alpha_y, beta_y, eta_y, etap_y = row.split(None, 13)
+            try:
+                l = float(l)
+            except ValueError:
+                l = 0.0
+            table_rows.append({"element": name, "s": s, "l": l, 
+                               "alpha_x": alpha_x, "beta_x": beta_x, "eta_x": eta_x, "etap_x": etap_x,
+                               "alpha_y": alpha_y, "beta_y": beta_y, "eta_y": eta_y, "etap_y": etap_y})
+        return table_rows
+    
+    async def refresh_pva_table(self):
+        """
+        This loop continuously checks if the PVAccess table needs to be refreshed,
+        and publishes a new table if it does.  The model_has_changed flag is
+        usually set when a tao command beginning with 'set' occurs.
+        """
+        while True:
+            if self.pva_needs_refresh:
+                self.pv.post(self.get_twiss_table())
+                self.pva_needs_refresh = False
+            await asyncio.sleep(1.0)
+    
+    async def broadcast_model_changes(self):
+        """
+        This loop broadcasts new orbits, twiss parameters, etc. over ZMQ.
+        """
+        while True:
+            if self.need_zmq_broadcast:
+                self.send_orbit()
+                self.send_profiles_twiss()
+                self.send_prof_orbit()
+                self.send_und_twiss()
+                self.need_zmq_broadcast = False
+            await asyncio.sleep(0.1)
+    
+    def model_changed(self):
+        self.pva_needs_refresh = True
+        self.need_zmq_broadcast = True
     
     def set_corrector_strength(self, name, new_strength, axis=None):
         if not axis:
@@ -47,39 +107,34 @@ class ModelService:
             axis = "v"
         if axis not in ["h", "v"]:
             raise Exception("Invalid Axis")
-        result = self.tao.cmd("set ele {element} {axis}kick = {strength}".format(element=name, axis=axis, strength=new_strength))
+        result = self.tao_cmd("set ele {element} {axis}kick = {strength}".format(element=name, axis=axis, strength=new_strength))
         result = "".join(result)
         if "ERROR" in result:
             raise Exception(result)
         else:
-            self.send_orbit()
-            self.send_profiles_twiss() 
-            self.send_prof_orbit()
-            self.send_und_twiss()
+            self.model_changed()
         
     
     def get_orbit(self):
         #Get X Orbit
-        x_orb_text = self.tao.cmd("show data orbit.x")[3:-2]
+        x_orb_text = self.tao_cmd("show data orbit.x")[3:-2]
         x_orb = _orbit_array_from_text(x_orb_text)
         #Get Y Orbit
-        y_orb_text = self.tao.cmd("show data orbit.y")[3:-2]
+        y_orb_text = self.tao_cmd("show data orbit.y")[3:-2]
         y_orb = _orbit_array_from_text(y_orb_text)
         return np.stack((x_orb, y_orb))
 
     def get_prof_orbit(self):
         #Get X Orbit
-        x_orb_text = self.tao.cmd("show data orbit.profx")[3:-2]
+        x_orb_text = self.tao_cmd("show data orbit.profx")[3:-2]
         x_orb = _orbit_array_from_text(x_orb_text)
         #Get Y Orbit
-        y_orb_text = self.tao.cmd("show data orbit.profy")[3:-2]
+        y_orb_text = self.tao_cmd("show data orbit.profy")[3:-2]
         y_orb = _orbit_array_from_text(y_orb_text)
         return np.stack((x_orb, y_orb))
     
-  
-
     def get_twiss(self):
-        twiss_text = self.tao.cmd("show lat -no_label_lines -at alpha_a -at beta_a -at alpha_b -at beta_b UNDSTART")
+        twiss_text = self.tao_cmd("show lat -no_label_lines -at alpha_a -at beta_a -at alpha_b -at beta_b UNDSTART")
         #format to list of comma separated values
         msg='twiss from get_twiss: {}'.format(twiss_text)
         L.info(msg)
@@ -88,10 +143,10 @@ class ModelService:
 
     def old_get_orbit(self):
         #Get X Orbit
-        x_orb_text = self.tao.cmd("python lat_list 1@0>>BPM*|model orbit.vec.1")
+        x_orb_text = self.tao_cmd("python lat_list 1@0>>BPM*|model orbit.vec.1")
         x_orb = _orbit_array_from_text(x_orb_text)
         #Get Y Orbit
-        y_orb_text = self.tao.cmd("python lat_list 1@0>>BPM*|model orbit.vec.3")
+        y_orb_text = self.tao_cmd("python lat_list 1@0>>BPM*|model orbit.vec.3")
         y_orb = _orbit_array_from_text(y_orb_text)
         return np.stack((x_orb, y_orb))
    
@@ -113,7 +168,7 @@ class ModelService:
 
     def send_profiles_twiss(self):
         L.info('Sending Profile');
-        twiss_text = np.asarray(self.tao.cmd("show lat -at beta_a -at beta_b Instrument::OTR*,Instrument::YAG*"))
+        twiss_text = np.asarray(self.tao_cmd("show lat -at beta_a -at beta_b Instrument::OTR*,Instrument::YAG*"))
         metadata = {"tag" : "prof_twiss", "dtype": str(twiss_text.dtype), "shape": twiss_text.shape}
         self.model_broadcast_socket.send_pyobj(metadata, zmq.SNDMORE)
         self.model_broadcast_socket.send(np.stack(twiss_text));        
@@ -123,6 +178,14 @@ class ModelService:
         metadata = {"tag": "und_twiss"}
         self.model_broadcast_socket.send_pyobj(metadata, zmq.SNDMORE)
         self.model_broadcast_socket.send_pyobj(twiss)
+    
+    def tao_cmd(self, cmd):
+        if cmd.startswith("exit"):
+            return "Please stop trying to exit the model service's Tao, you jerk!"
+        result = self.tao.cmd(cmd)
+        if cmd.startswith("set"):
+            self.model_changed()
+        return result
     
     async def recv(self):
         s = self.ctx.socket(zmq.REP)
@@ -139,26 +202,28 @@ class ModelService:
                     await s.send_pyobj({'status': 'fail', 'err': e})
             elif p['cmd'] == 'tao':
                 try:
-                    retval = self.tao.cmd(p['val'])
+                    retval = self.tao_cmd(p['val'])
                     await s.send_pyobj({'status': 'ok', 'result': retval})
                 except Exception as e:
                     await s.send_pyobj({'status': 'fail', 'err': e})
             elif p['cmd'] == 'send_orbit':
                 try:
-                    self.send_orbit()
+                    
+                    self.model_changed() #Sets the flag that will cause an orbit broadcast
                     await s.send_pyobj({'status': 'ok'})
                 except Exception as e:
                     await s.send_pyobj({'status': 'fail', 'err': e})
             elif p['cmd'] == 'echo':
                     await s.send_pyobj({'status': 'ok', 'result': p['val']})
             elif p['cmd'] == 'send_profiles_twiss':
-                self.send_profiles_twiss()
-                self.send_prof_orbit()
+                self.model_changed() #Sets the flag that will cause a prof broadcast
+                #self.send_profiles_twiss()
+                #self.send_prof_orbit()
                 await s.send_pyobj({'status': 'ok'})
             elif p['cmd'] == 'send_und_twiss':
-                self.send_und_twiss()
+                self.model_changed() #Sets the flag that will cause an und twiss broadcast
+                #self.send_und_twiss()
                 await s.send_pyobj({'status': 'ok'})
-    
 
 def _orbit_array_from_text(text):
     return np.array([float(l.split()[5]) for l in text])*1000.0

--- a/model_service/model_service.py
+++ b/model_service/model_service.py
@@ -207,12 +207,8 @@ class ModelService:
                 except Exception as e:
                     await s.send_pyobj({'status': 'fail', 'err': e})
             elif p['cmd'] == 'send_orbit':
-                try:
-                    
-                    self.model_changed() #Sets the flag that will cause an orbit broadcast
-                    await s.send_pyobj({'status': 'ok'})
-                except Exception as e:
-                    await s.send_pyobj({'status': 'fail', 'err': e})
+                self.model_changed() #Sets the flag that will cause an orbit broadcast
+                await s.send_pyobj({'status': 'ok'})
             elif p['cmd'] == 'echo':
                     await s.send_pyobj({'status': 'ok', 'result': p['val']})
             elif p['cmd'] == 'send_profiles_twiss':

--- a/obstruct_service/obstruct_service.py
+++ b/obstruct_service/obstruct_service.py
@@ -328,10 +328,6 @@ class ObstructorService(simulacrum.Service):
             L.info(msg)
         #restart global computation
         self.cmd_socket.send_pyobj({"cmd": "tao", "val": "set global lattice_calc_on=T"})
-        #update orbit?
-        msg = self.cmd_socket.recv_pyobj()['result']
-        L.info(msg)
-        self.cmd_socket.send_pyobj({"cmd": "send_orbit"})
         msg = self.cmd_socket.recv_pyobj()['result']
         L.info(msg)
     

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ classifiers = [
     'License :: OSI Approved :: BSD License'
 ]
 
-install_requires=['caproto']
+install_requires=['caproto', 'numpy', 'p4p', 'pyzmq']
 
 setup(name='simulacrum',
       version=versioneer.get_version(),


### PR DESCRIPTION
This PR does two main things:
- Adds a PVAccess server to the Model Service, which hosts a PV that has a table of twiss values.
- Changes the way the Model Service broadcasts orbits/twiss parameters/etc.  There is now a 10 Hz timer that emits broadcasts, if a `model_changed` flag is set.  Any Tao command that starts with "set" will set the `model_changed` flag.  The old commands that used to force a broadcast (`send_orbit`, `send_profiles_twiss`, and `send_und_twiss`) now simply set the `model_changed` flag.  Services that used to call any of the `send_*` commands after changing the model have been updated as necessary.

Other small changes:
- An obsolete model command to change corrector strengths was removed
- More python requirements were added to the setup.py file
- You can no longer accidentally stop the Model Service's Tao instance by sending an 'exit' command via ZeroMQ