### PR TITLE
Add support for waveform PVs in Generic PV Service.

### DIFF
--- a/generic_pv_service/generic_pv_service.py
+++ b/generic_pv_service/generic_pv_service.py
@@ -1,4 +1,6 @@
 import os
+import json
+import numpy as np
 from caproto import (ChannelString, ChannelEnum, ChannelDouble,
                      ChannelChar, ChannelData, ChannelInteger,
                      ChannelByte, ChannelShort, AccessRights,
@@ -96,7 +98,18 @@ class GenericPVService(simulacrum.Service):
                 initial_value = None
                 if len(pv_args) > 2:
                     initial_value = pv_args[2]
-                chan = make_channel(pv, type_for_pv, initial_value=class_for_type[type_for_pv](initial_value))
+                    array_value = None
+                    try:
+                        parsed_val = json.loads(initial_value)
+                        if isinstance(parsed_val, list):
+                            array_value = np.array(parsed_val)
+                    except ValueError:
+                        pass
+                    if array_value is not None:
+                        initial_value = array_value
+                    else:
+                        initial_value = class_for_type[type_for_pv](initial_value)
+                chan = make_channel(pv, type_for_pv, initial_value=initial_value)
                 self[pv] = chan
         
 def main():

--- a/generic_pv_service/pvs.txt
+++ b/generic_pv_service/pvs.txt
@@ -1,16 +1,20 @@
 # Define your PVs in here.
 # Lines that begin with "#" are comments, and ignored by the service.
+#
 # The format is as follows:
 # PV_NAME TYPE INITIAL_VAL
+#
 # Where PV_NAME is what you want the PV to be called
 # TYPE is a string corresponding to a python type: (str, float, int, bool, or bytes)
 # INITIAL_VAL is the value you want the PV to have at the start.
 # Here's a full example:
 # GDET:FEE1:241:ENRC float 3.3
 # Will create a PV called GDET:FEE1:241:ENRC, that holds a floating point number, initially 3.3
+#
+# You can also create waveform PVs by specifying an array as the initial value:
+# MY:ARRAY float [0.1, 1.2, 2.3]
 
 SIOC:SYS0:ML00:CALC252 float 175.8759
 EVNT:SYS0:1:LCLSBEAMRATE float 120 
 BEND:DMP1:400:BDES float 13.94
 BLEN:LI24:886:BIMAX float 5042
-


### PR DESCRIPTION
This PR lets you create waveform PVs with the Generic PV Service.  In pvs.txt, you just specify an array as the initial value, like this:

```
MY:FLOAT:ARRAY float [0.1, 1.2, 2.3]
MY:INT:ARRAY int [1, 2, 3]
MY:STRING:ARRAY str ["a", "b", "c"]
```