### PR TITLE
Fix the logic for turning klystrons on and off

### DIFF
--- a/klystron_service/klystron_service.py
+++ b/klystron_service/klystron_service.py
@@ -13,7 +13,7 @@ L = simulacrum.util.SimulacrumLog(os.path.splitext(os.path.basename(__file__))[0
 
 class KlystronPV(PVGroup):
     pdes = pvproperty(value=0.0, name=':PDES')  
-    phas = pvproperty(value=0.0, name=':PHAS')
+    phas = pvproperty(value=0.0, name=':PHAS', read_only=True)
     enld = pvproperty(value=0.0, name=':ENLD')
     # The seemingly random numbers in clear_* are the values these status
     # PVs have when a klystron is working normally, with no faults.


### PR DESCRIPTION
This was broken before - you could end up with Tao thinking the klystron was on, even though either high voltage or triggers were off.  Now all of this logic is properly handled at the Klystron PV level.  Additional bonus fix: The ":PHAS" PV is no longer writable (which would cause the model and the PVs to become inconsistent).