### PR TITLE
Fix BCTRL initial value.

### DIFF
--- a/klystron_service/klystron_service.py
+++ b/klystron_service/klystron_service.py
@@ -46,7 +46,7 @@ class KlystronPV(PVGroup):
     phas = pvproperty(value=0.0, name=':PHAS', read_only=True)
     enld = pvproperty(value=0.0, name=':ENLD')
     ades = pvproperty(value=0.0, name=':ADES')
-    ades = pvproperty(value=0.0, name=':AMPL')
+    ampl = pvproperty(value=0.0, name=':AMPL')
     bvjt = pvproperty(value=0.0, name=':BVJT')
     mkbvftpjasigma = pvproperty(value=0.0, name=':MKBVFTPJASIGMA')
     poly = pvproperty(value=np.zeros(6), name=':POLY', dtype=ChannelType.DOUBLE)

--- a/magnet_service/magnet_service.py
+++ b/magnet_service/magnet_service.py
@@ -51,6 +51,7 @@ class MagnetPV(PVGroup):
         self.bcon._data['value'] = float(initial_value['bact'])
         self.bdes._data['value'] = float(initial_value['bact'])
         self.bact._data['value'] = float(initial_value['bact'])
+        self.bctrl._data['value'] = float(initial_value['bact'])
         if 'precision' in initial_value:
             prec = int(initial_value['precision'])
             self.bcon._data['precision'] = prec


### PR DESCRIPTION
This PR fixes a bug where magnet BCTRL PVs didn't get initialized with the magnet strength.  Also includes a bonus fix: the "AMPL" PV in the klystron service was overwriting the "ADES" PV.  Whoops!