### PR TITLE
Make sure BCTRL follows BACT on trim and perturb commands.

### DIFF
--- a/magnet_service/magnet_service.py
+++ b/magnet_service/magnet_service.py
@@ -128,6 +128,13 @@ class MagnetPV(PVGroup):
         await ioc.ctrl.write("PERTURB")
         return value
     
+    @bact.putter
+    async def bact(self, instance, value):
+        ioc = instance.group
+        self.bctrl._data['value'] = value
+        await self.bctrl.publish(0)
+        return value
+    
     @bdes.putter
     async def bdes(self, instance, value):
         ioc = instance.group


### PR DESCRIPTION
This fixes a bug where changing BDES then issuing a "TRIM" or "PERTURB" command would update the BACT, but not the BCTRL.