### PR TITLE
Fix twiss table for Bmad dist 1112 and above

### DIFF
--- a/model_service/model_service.py
+++ b/model_service/model_service.py
@@ -112,7 +112,7 @@ class ModelService:
         for i in range(0,last_element_index+1):
             element_name = element_name_list[i]
             try:
-                device_name = util.convert_element_to_device(element_name)
+                device_name = simulacrum.util.convert_element_to_device(element_name)
             except KeyError:
                 device_name = ""
             element_rmat = element_data['ele.mat6'][i]


### PR DESCRIPTION
Bmad distributions >= 1112 changed the python lat_list behavior to exclude some elements that were previously included.  This caused inconsistencies in the twiss table (where the wrong values were being used for some elements).  This PR fixes that, but unfortunately it means using distributions < 1112 is no longer supported.