### PR TITLE
Fix magnet limits for BY1 and BX31 strings

### DIFF
--- a/magnet_service/magnet_limits.json
+++ b/magnet_service/magnet_limits.json
@@ -10313,11 +10313,11 @@
 	},
 	"BEND:LTUH:220": {
 		"PREC": 7,
-		"EGU": "kG-m",
-		"DRVH": -0.51,
-		"DRVL": 0.51,
-		"HOPR": -0.51,
-		"LOPR": 0.51
+		"EGU": "GeV/c",
+		"DRVH": 17.431,
+		"DRVL": 0.055,
+		"HOPR": 17.431,
+		"LOPR": 0.055
 	},
 	"XCOR:LTUH:248": {
 		"PREC": 7,
@@ -10353,11 +10353,11 @@
 	},
 	"BEND:LTUH:280": {
 		"PREC": 7,
-		"EGU": "kG-m",
-		"DRVH": -0.51,
-		"DRVL": 0.51,
-		"HOPR": -0.51,
-		"LOPR": 0.51
+		"EGU": "GeV/c",
+		"DRVH": 17.431,
+		"DRVL": 0.055,
+		"HOPR": 17.431,
+		"LOPR": 0.055
 	},
 	"QUAD:LTUH:285": {
 		"PREC": 7,
@@ -10529,11 +10529,11 @@
 	},
 	"BEND:LTUH:420": {
 		"PREC": 7,
-		"EGU": "kG-m",
-		"DRVH": -0.51,
-		"DRVL": 0.51,
-		"HOPR": -0.51,
-		"LOPR": 0.51
+		"EGU": "GeV/c",
+		"DRVH": 17.431,
+		"DRVL": 0.055,
+		"HOPR": 17.431,
+		"LOPR": 0.055
 	},
 	"QUAD:LTUH:445": {
 		"PREC": 7,
@@ -10577,11 +10577,11 @@
 	},
 	"BEND:LTUH:480": {
 		"PREC": 7,
-		"EGU": "kG-m",
-		"DRVH": -0.51,
-		"DRVL": 0.51,
-		"HOPR": -0.51,
-		"LOPR": 0.51
+		"EGU": "GeV/c",
+		"DRVH": 17.431,
+		"DRVL": 0.055,
+		"HOPR": 17.431,
+		"LOPR": 0.055
 	},
 	"QUAD:LTUH:485": {
 		"PREC": 7,

--- a/magnet_service/magnet_limits.json
+++ b/magnet_service/magnet_limits.json
@@ -10217,11 +10217,11 @@
 	},
 	"BEND:LTUH:125": {
 		"PREC": 7,
-		"EGU": "kG-m",
-		"DRVH": 1.3,
-		"DRVL": -1.3,
-		"HOPR": 1.3,
-		"LOPR": -1.3
+		"EGU": "GeV/c",
+		"DRVH": 17.5,
+		"DRVL": 0.097,
+		"HOPR": 17.5,
+		"LOPR": 0.097
 	},
 	"QUAD:LTUH:130": {
 		"PREC": 7,
@@ -10273,11 +10273,11 @@
 	},
 	"BEND:LTUH:175": {
 		"PREC": 7,
-		"EGU": "kG-m",
-		"DRVH": 1.3,
-		"DRVL": -1.3,
-		"HOPR": 1.3,
-		"LOPR": -1.3
+		"EGU": "GeV/c",
+		"DRVH": 17.5,
+		"DRVL": 0.097,
+		"HOPR": 17.5,
+		"LOPR": 0.097
 	},
 	"XCOR:LTUH:178": {
 		"PREC": 7,


### PR DESCRIPTION
The magnet limits were all wrong for the bends in the LTUH that are part of DL2.  This fixes that.  NOTE: These limits come from the classic machine, might need to be revised for CU_HXR once better numbers are available.