### PR TITLE
CU_SXR Fixes

### DIFF
--- a/magnet_service/magnet_limits.json
+++ b/magnet_service/magnet_limits.json
@@ -9769,26 +9769,26 @@
 	},
 	"BEND:CLTS:180": {
 		"PREC": 7,
-		"EGU": "kG-m",
-		"DRVH": 0.246,
-		"DRVL": -0.246,
-		"HOPR": 0.246,
-		"LOPR": -0.246
+		"EGU": "GeV/c",
+		"DRVH": 17.9028,
+		"DRVL": -0.2388,
+		"HOPR": 17.9028,
+		"LOPR": -0.2388
 	},
 	"BEND:CLTS:190": {
 		"PREC": 7,
-		"EGU": "kG-m",
-		"DRVH": 0.246,
-		"DRVL": -0.246,
-		"HOPR": 0.246,
-		"LOPR": -0.246
+		"EGU": "GeV/c",
+		"DRVH": 17.9028,
+		"DRVL": -0.2388,
+		"HOPR": 17.9028,
+		"LOPR": -0.2388
 	},
 	"BEND:CLTS:280": {
 		"PREC": 7,
-		"EGU": "kG-m",
-		"DRVH": 3.34,
+		"EGU": "GeV/c",
+		"DRVH": 15.606,
 		"DRVL": 0.0,
-		"HOPR": 3.34,
+		"HOPR": 15.606,
 		"LOPR": 0.0
 	},
 	"QUAD:CLTS:420": {
@@ -9857,10 +9857,10 @@
 	},
 	"BEND:CLTS:505": {
 		"PREC": 7,
-		"EGU": "kG-m",
-		"DRVH": 0.15,
+		"EGU": "GeV/c",
+		"DRVH": 11.8406,
 		"DRVL": 0.0,
-		"HOPR": 0.15,
+		"HOPR": 11.8406,
 		"LOPR": 0.0
 	},
 	"QUAD:CLTS:510": {
@@ -9889,10 +9889,10 @@
 	},
 	"BEND:CLTS:535": {
 		"PREC": 7,
-		"EGU": "kG-m",
-		"DRVH": 0.15,
+		"EGU": "GeV/c",
+		"DRVH": 11.8406,
 		"DRVL": 0.0,
-		"HOPR": 0.15,
+		"HOPR": 11.8406,
 		"LOPR": 0.0
 	},
 	"QUAD:CLTS:540": {
@@ -9961,10 +9961,10 @@
 	},
 	"BEND:CLTS:765": {
 		"PREC": 7,
-		"EGU": "kG-m",
-		"DRVH": 3.36,
+		"EGU": "GeV/c",
+		"DRVH": 22.8966,
 		"DRVL": 0.0,
-		"HOPR": 3.36,
+		"HOPR": 22.8966,
 		"LOPR": 0.0
 	},
 	"QUAD:BSYH:445": {

--- a/magnet_service/magnet_service.py
+++ b/magnet_service/magnet_service.py
@@ -401,7 +401,7 @@ class Bend:
             field_units = "GeV/c"
             b_field_tesla = ((-1.0 * 10**9 * b_field * self.g)/2.99792458e8)
         b_field_error =  b_field_tesla - self.b_init_tesla
-        L.debug("%s: Converted %f %s to %f T.  b_init = %f, b_err = %f", self.name, b_field, field_units, b_field_tesla, self.b_init_tesla, b_field_error)
+        L.debug("%s: Converted %f %s to %f T.  b_init = %f, b_err = %f", self.element_name, b_field, field_units, b_field_tesla, self.b_init_tesla, b_field_error)
         return b_field_error
     
     def convert_tesla_to_epics_units(self, b_field_tesla):
@@ -414,10 +414,10 @@ class Bend:
     
     def set_field_strength_command(self, b_field):
         if self.bend_type == "chicane":
-            b_err = element.convert_to_b_field_err(b_field/self.l)
+            b_err = self.convert_to_b_field_err(b_field/self.l)
         elif self.bend_type == "dogleg":
-            b_err = element.convert_to_b_field_err(b_field)
-        return f"set ele {element.name} b_field_err = {b_err}"
+            b_err = self.convert_to_b_field_err(b_field)
+        return f"set ele {self.element_name} b_field_err = {b_err}"
     
     def make_pv(self, read_only, precision=None, upper_ctrl_limit=None, lower_ctrl_limit=None, change_callback=None):
         init_vals = {"bact": self.convert_tesla_to_epics_units(self.b_init_tesla), "units": self.unit}

--- a/magnet_service/magnet_service.py
+++ b/magnet_service/magnet_service.py
@@ -408,7 +408,10 @@ class Bend:
         if self.bend_type == "chicane":
             b_field_kgm = -10.0 * math.copysign(1, self.g) * b_field_tesla * self.l
         elif self.bend_type == "dogleg":
-            b_field_kgm = -1.0 * 2.99792458e8 * b_field_tesla / (self.g * 10**9)
+            if self.g == 0:
+              b_field_kgm = 0.0
+            else:
+              b_field_kgm = -1.0 * 2.99792458e8 * b_field_tesla / (self.g * 10**9)
         L.debug("%s: Converted %f T to %f kGm.  Length is %f", self.element_name, b_field_tesla, b_field_kgm, self.l)
         return b_field_kgm
     


### PR DESCRIPTION
This PR fixes some magnet problems that were found when testing the CU_SXR line:

- Magnets with g==0 no longer crash the magnet service.
- Several crashes when converting to/from EPICS units are fixed.
- Magnet limits for CLTS bends are now correct.  Limits for non-bends are probably still wrong.