### PR TITLE
Basic mkdocs documentation

### DIFF
--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -1,0 +1,40 @@
+# SLAC Developer setup
+
+## Bmad Production Environment
+
+The current version of the Bmad distribution can be enabled with:
+
+```bash
+source /usr/local/lcls/package/bmad_distributions/enable
+``` 
+
+
+### Python
+
+The standard Python 3.7 environment is enabled with:
+```bash
+source /usr/local/lcls/package/anaconda/envs/python3.7env/bin/activate
+```
+
+Custom packages are maintained in `/usr/local/lcls/model/python`:
+```bash
+export PYTHONPATH=$PYTHONPATH:/usr/local/lcls/model/python
+```
+
+
+
+### Lattice files
+
+Lattice files are maintained in standard locations, and are referred to with these standard environmental variables:
+
+```bash
+export LCLS_LATTICE=/usr/local/lcls/model/lattice/lcls-lattice
+export LCLS_CLASSIC_LATTICE=/usr/local/lcls/model/lattice/lcls-classic-lattice
+```
+
+These files are updated with `git`:
+
+```bash
+cd /usr/local/lcls/model/lattice/lcls-lattice
+git pull -r
+```

--- a/docs/developer/mkdocs.md
+++ b/docs/developer/mkdocs.md
@@ -1,0 +1,29 @@
+# Updating this documentation
+
+
+These docs are created using mkdocs:
+
+
+## Setup
+
+```bash
+conda install mkdocs pygments mkdocs-material
+
+pip install 
+```
+
+## Deploy to GitHub pages
+
+```bash
+mkdocs gh-deploy
+```
+
+
+
+## SLAC clone
+
+A clone of the lcls-live gh-pages branch is here
+
+`/afs/slac/www/grp/ad/docs/python/lcls-live`
+
+and are served [here](https://www.slac.stanford.edu/grp/ad/docs/python/lcls-live/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# Simulacrum Documentation
+
+For full source see [simulacrum](https://github.com/slaclab/simulacrum) on GitHub.
+
+## TODO
+
+```python
+stuff
+```

--- a/docs/other/index.md
+++ b/docs/other/index.md
@@ -1,0 +1,33 @@
+# Other resources
+
+
+## PyDM
+
+[Tutorial](https://www.slac.stanford.edu/grp/ad/docs/python/pydm-tutorial/)
+
+[Documentation](https://www.slac.stanford.edu/grp/ad/docs/python/pydm/)
+
+
+## Matlab
+
+[Matlab Programmers Guide](https://www.slac.stanford.edu/grp/ad/docs/model/matlab/programmers_guide.html)
+
+
+[Software release procedure](https://www.slac.stanford.edu/grp/ad/docs/model/matlab/programmers_guide.html#appendix_b:_software_release_procedure)
+
+[Cheatsheet](https://www.slac.stanford.edu/grp/ad/docs/model/matlab/cheatsheet.html)
+
+## MAD Lattices
+
+[MAD Lattice release](https://www.slac.stanford.edu/grp/ad/model/lcls.html)
+
+## Device, element name and PV name references
+
+[Oracle](https://oraweb.slac.stanford.edu/apex/slacprod/f?p=116)
+
+[File](https://www.slac.stanford.edu/cgi-bin/cvsweb/optics/script/elementdevices.dat?cvstag=HEAD&content-type=text/x-cvsweb-markup&cvsroot=LCLS)
+
+Directory Service (see [1] for meme_names.m, and [2] for eget –s ds 
+
+[Beamline Boundaries](https://docs.slac.stanford.edu/sites/pub/Publications/Beamline%20Boundaries.pdf)
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,24 @@
+
+
+nav:
+  - index.md
+  - Developer: 
+    - developer/index.md
+    - mkdocs: developer/mkdocs.md
+  
+  - other/index.md
+  
+  
+  
+site_name: Simulacrum
+
+theme:
+  name: 'material'
+  
+  
+markdown_extensions:
+  - codehilite  
+  
+plugins:
+    - search
+    - minify


### PR DESCRIPTION
I added basic docs, which mkdocs can use to generate static HTML on the gh-pages branch. 

GitHub Pages needs to be activated in settings.

mkdocs is installed via:

```bash
conda install mkdocs pygments mkdocs-material
pip install 
```

and then in the simulacrum root directory, run:

```bash
mkdocs gh-deploy
```
